### PR TITLE
Add Magento 2.2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "avstudnitz/disable-modules",
     "description": "N/A",
     "require": {
-        "magento/framework": "~100.0"
+        "magento/framework": "~100.0|~101.0"
     },
     "type": "magento2-module",
     "version": "1.0.0",


### PR DESCRIPTION
On Magento 2.2 I'm getting output like the following:
```
$ composer require --dev avstudnitz/disable-modules
Using version ^1.0 for avstudnitz/disable-modules                                        
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)                                            
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for avstudnitz/disable-modules ^1.0 -> satisfiable by avstudnitz/disable-modules[1.0.0].
    - Conclusion: remove magento/framework 101.0.2
    - Conclusion: don't install magento/framework 101.0.2
    - avstudnitz/disable-modules 1.0.0 requires magento/framework ~100.0 -> satisfiable by magento/framework[100.0.2, 100.0.3, 100.0.4, 100.0.5, 100.0.6, 100.0.7, 100.0.8, 100.0.9, 100.1.0, 100.0.10, 100.0.11, 100.1.1, 100.0.12, 100.1.2, 100.1.3, 100.0.13, 100.1.4, 100.0.14, 100.1.5, 100.0.15, 100.1.6, 100.1.7, 100.0.16, 100.0.17, 100.1.8, 100.1.9, 100.0.18, 100.0.19, 100.1.10, 100.1.11, 100.0.20, 100.1.12].
    - Can only install one of: magento/framework[101.0.2, 100.0.2].
    - Can only install one of: magento/framework[101.0.2, 100.0.3].
    - Can only install one of: magento/framework[101.0.2, 100.0.4].
    - Can only install one of: magento/framework[101.0.2, 100.0.5].
    - Can only install one of: magento/framework[101.0.2, 100.0.6].
    - Can only install one of: magento/framework[101.0.2, 100.0.7].
    - Can only install one of: magento/framework[101.0.2, 100.0.8].
    - Can only install one of: magento/framework[101.0.2, 100.0.9].
    - Can only install one of: magento/framework[101.0.2, 100.1.0].
    - Can only install one of: magento/framework[101.0.2, 100.0.10].
    - Can only install one of: magento/framework[101.0.2, 100.0.11].
    - Can only install one of: magento/framework[101.0.2, 100.1.1].
    - Can only install one of: magento/framework[101.0.2, 100.0.12].
    - Can only install one of: magento/framework[101.0.2, 100.1.2].
    - Can only install one of: magento/framework[101.0.2, 100.1.3].
    - Can only install one of: magento/framework[101.0.2, 100.0.13].
    - Can only install one of: magento/framework[101.0.2, 100.1.4].
    - Can only install one of: magento/framework[101.0.2, 100.0.14].
    - Can only install one of: magento/framework[101.0.2, 100.1.5].
    - Can only install one of: magento/framework[101.0.2, 100.0.15].
    - Can only install one of: magento/framework[101.0.2, 100.1.6].
    - Can only install one of: magento/framework[101.0.2, 100.1.7].
    - Can only install one of: magento/framework[101.0.2, 100.0.16].
    - Can only install one of: magento/framework[101.0.2, 100.0.17].
    - Can only install one of: magento/framework[101.0.2, 100.1.8].
    - Can only install one of: magento/framework[101.0.2, 100.1.9].
    - Can only install one of: magento/framework[101.0.2, 100.0.18].
    - Can only install one of: magento/framework[101.0.2, 100.0.19].
    - Can only install one of: magento/framework[101.0.2, 100.1.10].
    - Can only install one of: magento/framework[101.0.2, 100.1.11].
    - Can only install one of: magento/framework[101.0.2, 100.0.20].
    - Can only install one of: magento/framework[101.0.2, 100.1.12].
    - Installation request for magento/framework (locked at 101.0.2) -> satisfiable by magento/framework[101.0.2].
```