### PR TITLE
[FIX] - removed versioned magento framework dependecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "avstudnitz/disable-modules",
     "description": "N/A",
     "require": {
-        "magento/framework": "~100.0|~101.0"
+        "magento/framework": "*"
     },
     "type": "magento2-module",
     "version": "1.0.0",


### PR DESCRIPTION
When using php7.1 and magento 2.2.x this module cannot be installed via composer because the dependency on the framework ~101.0 requires php7.0. 