### PR TITLE
Adds compatibility with symfony/console v7.x

### DIFF
--- a/Console/Command/DependenciesShowRemovableCommand.php
+++ b/Console/Command/DependenciesShowRemovableCommand.php
@@ -8,11 +8,12 @@ use Magento\Framework\App\Utility\Files;
 use Magento\Framework\Component\ComponentRegistrar;
 use Magento\Framework\Component\ComponentRegistrarInterface;
 use Magento\Framework\Component\DirSearch;
+use Magento\Framework\Console\Cli;
 use Magento\Framework\View\Design\Theme\ThemePackageList;
+use Magento\Setup\Module\Dependency\Report\Dependency;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Magento\Setup\Module\Dependency\Report\Dependency;
 
 /**
  * Command for showing nmodules which can be removed / disabled
@@ -108,19 +109,21 @@ class DependenciesShowRemovableCommand extends \Symfony\Component\Console\Comman
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             Files::setInstance(new Files($this->registrar, $this->dirSearch, $this->themePackageList));
             $this->buildReport($input->getOption(self::INPUT_KEY_OUTPUT));
             $output->writeln('<info>Report successfully processed. File "' . $input->getOption(self::INPUT_KEY_OUTPUT) . '" generated.</info>');
+
+            return Cli::RETURN_SUCCESS;
         } catch (\Exception $e) {
             $output->writeln(
                 '<error>Please check the path you provided. Removable Modules report generator failed with error: ' .
                 $e->getMessage() . '</error>'
             );
             // we must have an exit code higher than zero to indicate something was wrong
-            return \Magento\Framework\Console\Cli::RETURN_FAILURE;
+            return Cli::RETURN_FAILURE;
         }
     }
 


### PR DESCRIPTION
Adds compatibility with `symfony/console` 7.x so we can use this module on Magento 2.4.9

Otherwise we get this error when executing `bin/magento`:

```
$ bin/magento cache:flush
PHP Fatal error:  Declaration of AvS\DisableModules\Console\Command\DependenciesShowRemovableCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in vendor/avstudnitz/disable-modules/Console/Command/DependenciesShowRemovableCommand.php on line 111
```

The addition of the `int` return type is backwards compatible with older versions of `symfony/console`, through php's [covariance](https://www.php.net/manual/en/language.oop5.variance.php#:~:text=Covariance%20allows%20a%20child%27s%20method%20to%20return%20a%20more%20specific%20type%20than%20the%20return%20type%20of%20its%20parent%27s%20method.).

This also incorporates the fix from @mzeis from https://github.com/avstudnitz/AvS_DisableModules/pull/16